### PR TITLE
[BUILD] CMAKE 3.25 -> 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.25)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.23)
 project(UserLogger)
 
 add_executable(UserLogger main.cpp sources/user.cpp)


### PR DESCRIPTION
Замечена проблема обратной совместимости на старых cmake. Понизила минимальную версию системы сборки в CMakeLists.txt